### PR TITLE
[feat] 채팅창에서 프로필 사진 클릭 시 프로필 모달 띄우기 #205

### DIFF
--- a/components/chats/ChatBox.tsx
+++ b/components/chats/ChatBox.tsx
@@ -2,16 +2,28 @@ import React from 'react';
 
 import { ChatBoxProps, ChatBoxType } from 'types/chatTypes';
 
+import useModalProvider from 'hooks/useModalProvider';
+
 import styles from 'styles/chats/ChatBox.module.scss';
 
 function ChatBox({ chatBoxProp }: { chatBoxProp: ChatBoxProps }) {
   const { chatUser, message, time, buttons } = chatBoxProp;
   const { imgUrl, nickname } = chatUser ?? {};
+  const { useProfileModal } = useModalProvider();
+
+  const imgClickHandler = () => {
+    if (!nickname) return;
+    useProfileModal(nickname);
+  };
 
   const chatBox: { [key in ChatBoxType]: JSX.Element } = {
     chatBox: (
       <div className={styles.chatBox}>
-        <img className={styles.chatterImg} src={imgUrl} />
+        <img
+          className={styles.chatterImg}
+          onClick={imgClickHandler}
+          src={imgUrl}
+        />
         <div className={styles.chatTexts}>
           <div className={styles.nickname}>{nickname}</div>
           <div className={styles.messageBox}>


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #205
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
채팅창에서 상대 채팅의 프로필 사진을 누르면 프로필 모달을 띄웁니다.
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 클릭시 띄우기
- 별 거 없음
## Etc
