### PR TITLE
[feat] 페이지 이동시 탭 상태 초기값으로 돌려주기 close #176

### DIFF
--- a/components/myPage/MyPageFrame.tsx
+++ b/components/myPage/MyPageFrame.tsx
@@ -1,5 +1,5 @@
 import useTranslation from 'next-translate/useTranslation';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 
 import React, { useEffect } from 'react';
 
@@ -17,6 +17,7 @@ import styles from 'styles/myPage/MyPage.module.scss';
 export default function MyPageFrame() {
   const { t } = useTranslation('myPage');
   const [tab, setTab] = useRecoilState(profileTabState);
+  const resetProfileTabState = useResetRecoilState(profileTabState);
   const [editable, setEditable] = useRecoilState(editableState);
   const { nickname } = useRecoilValue(userState);
   const { useEditWarningModal } = useModalProvider();
@@ -46,6 +47,7 @@ export default function MyPageFrame() {
 
   useEffect(() => {
     return () => {
+      resetProfileTabState();
       setEditable(false);
     };
   }, []);

--- a/pages/friends.tsx
+++ b/pages/friends.tsx
@@ -1,7 +1,7 @@
 import useTranslation from 'next-translate/useTranslation';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 
 import { dropdownUserState, friendsTabState } from 'recoils/friends';
 
@@ -18,7 +18,15 @@ import styles from 'styles/friends/Friends.module.scss';
 export default function Friends() {
   const { t } = useTranslation('friends');
   const resetDropdownUserState = useResetRecoilState(dropdownUserState);
+  const resetFriendsTabState = useResetRecoilState(friendsTabState);
   const [tab, setTab] = useRecoilState(friendsTabState);
+
+  useEffect(() => {
+    return () => {
+      resetFriendsTabState();
+      resetDropdownUserState();
+    };
+  }, []);
 
   const handleTabClick = (event: React.MouseEvent<HTMLDivElement>) => {
     const div = event.target as HTMLDivElement;


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #176
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
결과에 승복해 이제 친구/마이페이지엔 들어오면 항상 첫 번째 탭이 뜹니다.
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 유즈이펙트의 return을 사용해 언마운트될 때 스테이트를 리셋해줬습니다.

## Etc
