### PR TITLE
[fix] ChannelInfo interface 변수명 수정 #236

### DIFF
--- a/components/channels/channelSettings/CapacityRadio.tsx
+++ b/components/channels/channelSettings/CapacityRadio.tsx
@@ -8,14 +8,14 @@ export default function CapacityRadio({
   channelInfo,
   setChannelInfo,
 }: SettingFieldProps) {
-  const { capacity } = channelInfo;
+  const { maxCount } = channelInfo;
   const capacities = [10, 30, 50];
 
   const handleCapacityChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       setChannelInfo((prev) => ({
         ...prev,
-        capacity: Number(event.target.value),
+        maxCount: Number(event.target.value),
       }));
     },
     [channelInfo]
@@ -30,7 +30,7 @@ export default function CapacityRadio({
               type='radio'
               id={`${number}`}
               value={`${number}`}
-              checked={capacity === number}
+              checked={maxCount === number}
               onChange={handleCapacityChange}
             />
             {number}

--- a/components/channels/channelSettings/ChannelSettings.tsx
+++ b/components/channels/channelSettings/ChannelSettings.tsx
@@ -1,7 +1,7 @@
 import useTranslation from 'next-translate/useTranslation';
 import { useSetRecoilState } from 'recoil';
 
-import { FormEvent, SetStateAction, useState } from 'react';
+import { FormEvent, SetStateAction, useState, Dispatch } from 'react';
 
 import { openModalState } from 'recoils/modal';
 
@@ -19,7 +19,7 @@ import styles from 'styles/channels/ChannelSettings.module.scss';
 
 export type SettingFieldProps = {
   channelInfo: ChannelInfo;
-  setChannelInfo: React.Dispatch<SetStateAction<ChannelInfo>>;
+  setChannelInfo: Dispatch<SetStateAction<ChannelInfo>>;
 };
 
 type FieldType = {
@@ -141,5 +141,5 @@ export const defaultChannelSettings: ChannelInfo = {
   access: 'public',
   title: '',
   password: null,
-  capacity: 10,
+  maxCount: 10,
 };

--- a/types/channelTypes.ts
+++ b/types/channelTypes.ts
@@ -16,5 +16,5 @@ export interface ChannelInfo {
   access: string;
   title: string;
   password: string | null;
-  capacity: number;
+  maxCount: number;
 }


### PR DESCRIPTION
## Issue
+ Issue Number: https://github.com/Dr-Pong/dr_pong_client/issues/236
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
현재 capacity로 되어있는데 api 문서에는 maxCount로 명시되어 있어서
서버와 변수명을 일치시키기 위해 maxCount로 수정하겠습니다..!

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- ChannelInfo의 `capacity` -> `maxCount`

## Etc
