### PR TITLE
[fix] 드롭다운 백드롭으로 정신차리게 만들기 #327

### DIFF
--- a/components/myPage/profile/TitleDropdown.tsx
+++ b/components/myPage/profile/TitleDropdown.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 
-import React, { useState, Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { IoMdArrowDropdown } from 'react-icons/io';
 
 import { editableState } from 'recoils/user';
@@ -11,8 +11,8 @@ import { DetailDto } from 'types/userTypes';
 import useMyPageQuery from 'hooks/useMyPageQuery';
 
 import Dropdown from 'components/global/Dropdown';
-import LoadingSpinner from 'components/global/LoadingSpinner';
 import ErrorRefresher from 'components/global/ErrorRefresher';
+import LoadingSpinner from 'components/global/LoadingSpinner';
 
 import styles from 'styles/myPage/ProfileCard.module.scss';
 
@@ -40,12 +40,22 @@ export default function TitleDropdown({
     setDropdownVisibility(!dropdownVisibility);
   };
 
+  const handleBackdropClick = () => {
+    setDropdownVisibility(false);
+  };
+
   return (
     <div className={styles.titleDropdownContainer}>
       {editable && (
         <IoMdArrowDropdown
           className={styles.dropdownArrow}
           onClick={handleDropdownClick}
+        />
+      )}
+      {dropdownVisibility && (
+        <div
+          className={styles.dropdownBackdrop}
+          onClick={handleBackdropClick}
         />
       )}
       <Dropdown style={'title'} visibility={editable && dropdownVisibility}>

--- a/styles/myPage/ProfileCard.module.scss
+++ b/styles/myPage/ProfileCard.module.scss
@@ -47,3 +47,14 @@
   font-size: 1.5rem;
   cursor: pointer;
 }
+
+.dropdownBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #327
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
드롭다운에 백드롭을 달았습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 백드롭을 클릭하면 드롭다운이 닫힙니다.
- 근데 input(상메)만 이상하게 자꾸 클릭이 돼서.. 불가피하게 z-index 1 줬습니다..
- 이게 별로면 이벤트 리스너를 갖고 하라는데
- 뭐가 나을까요?

## Etc
