### PR TITLE
[fix] 처음 친구가 되었을 때 실시간으로 all을 보고있으면 status가 생기지 않는 문제 수정 #366

### DIFF
--- a/components/friends/FriendTabContents.tsx
+++ b/components/friends/FriendTabContents.tsx
@@ -35,7 +35,6 @@ export default function FriendTabContents() {
   const [globalChatSocket] = useChatSocket('global');
 
   useEffect(() => {
-    friendsChatSocket.emit('status');
     const friendStatusListener = (newStatuses: Statuses) => {
       setStatuses((prev) => {
         return {
@@ -68,6 +67,10 @@ export default function FriendTabContents() {
       globalChatSocket.off('friend', pendingsListener);
     };
   }, []);
+
+  useEffect(() => {
+    friendsChatSocket.emit('status');
+  }, [friends]);
 
   const query: {
     [key: string]: (setBlocks: (f: Friend[]) => void) => UseQueryResult;


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #366
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
친구가 될 때, 수락하는 쪽은 pending에서 누르고 all로 오기때문에 문제가 없지만
수락되는 쪽은, 만약 all에서 친구창을 째리고 있다면 status가 생기지 않는 문제가 있었습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- friendsChatSocket.emit('status')가 처음 all friends를 불러올 때 백에다 status 달라고 요청하는 부분인데요 
- 이 부분에 friends를 의존성으로 두어 친구 명단이 바뀔때마다 status를 프론트에서 자체적으로 갱신시키게 됩니다.

## Etc
