### PR TITLE
[fix] dm은 isMuted가 없지요.. #428

### DIFF
--- a/components/chats/ChattingsFrame.tsx
+++ b/components/chats/ChattingsFrame.tsx
@@ -82,7 +82,7 @@ export default function ChattingsFrame({
         userImageMap={userImageMap}
         roomType={roomType as RoomType}
         roomId={roomId as string}
-        isMuted={me.isMuted}
+        isMuted={me?.isMuted ?? false}
       />
     </>
   );


### PR DESCRIPTION
## Issue
+ Issue Number: https://github.com/Dr-Pong/dr_pong_client/issues/428
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
ChattingsFrame에서 channel이 아니라 dm일 때는 isMuted가 없다는 것을 알아버린 것에 대 하 여 . . .

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- `isMuted={me.isMuted}` -> `isMuted={me?.isMuted ?? false}`

## Etc
