### PR TITLE
[fix] 리더보드 빈 유저 클릭시 프로필이 열려버리는 문제.. #437

### DIFF
--- a/components/leaderboard/TopLeaders.tsx
+++ b/components/leaderboard/TopLeaders.tsx
@@ -37,6 +37,7 @@ export default function TopLeaders({ topLeaderCount }: TopLeadersProps) {
   ];
 
   const handleProfileClick = (nickname: string): (() => void) => {
+    if (!nickname) return () => null;
     return () => useProfileModal(nickname);
   };
 


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #437
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
제가 프로필 사진 눌러도 프로필이 뜨게 하면서 문제가 생겼습니다.
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 지송함다
- 
## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->
핸들러에서 닉네임 검사하기.

## Etc
