### PR TITLE
[feat] 승무패 정보 보여주기 on Records 페이지 #446

### DIFF
--- a/components/records/RecordBox.tsx
+++ b/components/records/RecordBox.tsx
@@ -60,7 +60,12 @@ export default function RecordBox({ record }: { record: Record }) {
         </div>
         <div className={styles.playerScoreWrap}>
           <Player nickname={me.nickname} imgUrl={me.imgUrl} />
-          <div className={styles.score}>{`${me.score} : ${you.score}`}</div>
+          <div className={styles.resultWrap}>
+            <div className={styles.score}>{`${me.score} : ${you.score}`}</div>
+            <div className={`${styles.resultText} ${styles[result]}`}>
+              {t(result)}
+            </div>
+          </div>
           <Player nickname={you.nickname} imgUrl={you.imgUrl} />
         </div>
       </div>

--- a/locales/en/records.json
+++ b/locales/en/records.json
@@ -15,5 +15,8 @@
   "show more": "show more",
   "no match": "No match history yet.",
   "How about logging in?": "Log in, enjoy the game and make your own records!",
-  "login": "Login"
+  "login": "Login",
+  "win": "Win",
+  "lose": "Lose",
+  "tie": "Tie"
 }

--- a/locales/ko/records.json
+++ b/locales/ko/records.json
@@ -15,5 +15,8 @@
   "show more": "더보기",
   "no match": "아직 전적 기록이 없습니다.",
   "How about logging in?": "로그인해서 게임을 즐기고 나만의 기록을 쌓아보세요!",
-  "login": "로그인"
+  "login": "로그인",
+  "win": "승",
+  "lose": "패",
+  "tie": "무"
 }

--- a/styles/records/RecordBox.module.scss
+++ b/styles/records/RecordBox.module.scss
@@ -33,6 +33,9 @@
 
 .basicContent {
   @include boxColumnGrid;
+  & img {
+    border-radius: $basic-radius;
+  }
 }
 
 .leftBox {
@@ -79,9 +82,30 @@
   cursor: pointer;
 }
 
-.score {
+.resultWrap {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+}
+
+.resultText {
+  margin-top: 0.2rem;
+  width: 2.5rem;
+  font-size: 1rem;
+  text-align: center;
+  border-radius: $basic-radius;
+  &.win {
+    border: solid 1px $light-blue;
+    color: $light-blue;
+  }
+  &.lose {
+    border: solid 1px $just-pink;
+    color: $just-pink;
+  }
+  &.tie {
+    border: solid 1px $dark-grey;
+    color: $dark-grey;
+  }
 }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #446
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
사진으로 보여드리겠습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- before
<img width="330" alt="스크린샷 2023-08-03 오후 1 35 55" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/457b2847-6e98-4f33-b3fa-89589ecad17c">

- after
<img width="330" alt="스크린샷 2023-08-03 오후 1 35 33" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/fd7e4ee7-6b0a-4eac-bee6-8660373fdb75">

- 막상 비교하니 별론거같아.. (충격)

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
