### PR TITLE
[fix] 게임 큐 기다릴때 스페이스바 누르면 에러 뜨는 문제 해결 #473

### DIFF
--- a/components/global/QueueSpinner.tsx
+++ b/components/global/QueueSpinner.tsx
@@ -17,6 +17,7 @@ export default function QueueSpinner({
   const [socket] = useChatSocket('global');
 
   useEffect(() => {
+    (document.activeElement as HTMLElement)?.blur();
     socket.on('deleteInvite', handleGameCancel);
 
     if (!useTimer) return () => socket.off('deleteInvite', handleGameCancel);


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #473
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
버튼을 누르면 포커스가 남아있어서
스페이스바를 누르면 버튼이 또 눌립니다.
그래서 게임 입장 하는 중에 또 입장 시도가 되어
백에서 400을 줍니다.
그래서 나는 에러였슴

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- document.activeElement는 현재 도큐먼트에서 포커스된 엘리먼트를 줍니다.
- .blur()는 포커스를 해제해줍니다.
- QueueSpinner가 mount될때 이넘을 딱! 딱.

## Etc
