### PR TITLE
[fix] 채팅창 유령문제 해결 #476

### DIFF
--- a/components/channels/participants/Participants.tsx
+++ b/components/channels/participants/Participants.tsx
@@ -29,7 +29,10 @@ export default function Participants() {
   const setAlert = useSetRecoilState(alertState);
   const { useChannelInvitationModal } = useModalProvider();
   const { mutationDelete } = useCustomQuery();
-  const { chatUsersGet } = useChatQuery(roomType as RoomType, roomId as string);
+  const { participantsGet } = useChatQuery(
+    roomType as RoomType,
+    roomId as string
+  );
 
   const channelLeaveMutation = mutationDelete(
     `/channels/${roomId}/participants`,
@@ -44,7 +47,7 @@ export default function Participants() {
     }
   );
 
-  const { data, isLoading, isError, error } = chatUsersGet();
+  const { data, isLoading, isError, error } = participantsGet();
   if (isLoading) return <LoadingSpinner />;
   if (isError) return <ErrorRefresher error={error} />;
 

--- a/components/chats/ChatsFrame.tsx
+++ b/components/chats/ChatsFrame.tsx
@@ -32,12 +32,12 @@ export default function ChatsFrame({ roomType, roomId }: ChatsFrameProps) {
     roomType as RoomType,
     roomId as string
   );
-  const chatUsers = chatUsersGet(setUserImageMap);
   const [socket] = useChatSocket(roomType);
 
   useEffect(() => {
     const participantsListener = () => {
-      queryClient.invalidateQueries('channelParticipants');
+      queryClient.invalidateQueries(['channelParticipants']);
+      queryClient.invalidateQueries(['participants']);
     };
     socket.on('participants', participantsListener);
     return () => {
@@ -49,6 +49,8 @@ export default function ChatsFrame({ roomType, roomId }: ChatsFrameProps) {
     channel: `${myChannelGet.data?.myChannel?.title}`,
     dm: `${roomId}`,
   };
+
+  const chatUsers = chatUsersGet(setUserImageMap);
 
   if (chatUsers.isLoading || myChannelGet.isLoading) return <LoadingSpinner />;
   if (chatUsers.isError) return <ErrorRefresher error={chatUsers.error} />;

--- a/hooks/useChatQuery.ts
+++ b/hooks/useChatQuery.ts
@@ -35,10 +35,14 @@ const useChatQuery = (roomType: RoomType, roomId: string) => {
     return roomType === 'dm'
       ? get('DMFriend', `/users/${roomId}/detail`, friendDetailToChatUser)
       : get(
-          'channelParticipants',
+          ['channelParticipants'],
           `/channels/${roomId}/participants`,
           participantsToChatUsers
         );
+  };
+
+  const participantsGet = () => {
+    return get(['participants'], `/channels/${roomId}/participants`);
   };
 
   const chatsGet = (handleChatJoin: (chats: Chat[]) => void, count: number) => {
@@ -84,7 +88,7 @@ const useChatQuery = (roomType: RoomType, roomId: string) => {
     );
   };
 
-  return { myChannelGet, chatUsersGet, chatsGet };
+  return { myChannelGet, chatUsersGet, chatsGet, participantsGet };
 };
 
 export default useChatQuery;


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #476
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
채팅창에 간헐적으로 유저 이미지가 출입에 따라 갱신되지 않는 문제를 해결했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 그 원인은 바로바로바로~~~~~~~~~~ 사이드바에 있었습니다!
- 원래 우리는 사이드바와 채팅창에서 같은 GET /channels/[roomId]/participants 요청을 사용했습니다.
- 그런데 차이는, 채팅창에서는 setUserImages가 들어가고 사이드바에선 아니라는점 ..! 이 세터가 바로 유저의 이미지를 넣어주는 녀석이었는데~~
- 그런데 두 곳에서 같은 요청을 사용하고 같은 쿼리키를 사용해서, 유저가 들어와서 invalidateQueries를 하면 두 컴포넌트에서 각각 세터가 있는/없는 함수가 호출되는 줄 알았습니다!
- 근데 호출은 마지막에 했던 거 한 번만해서 데이터만 갱신하나봐요.
- 그래서 사이드바를 켰다 끈 이후 부터는 모든 것이 숲으로 돌아가던 것이었습니다..
- 차암내..
- 완성주의적으로 대충 분리해줬습니다. ㅎㅎ

## Etc
