### PR TITLE
[fix] 채널 강퇴 시 사이드 바 모달 열려있으면 미아됨 #484

### DIFF
--- a/components/chats/Chattings.tsx
+++ b/components/chats/Chattings.tsx
@@ -7,6 +7,8 @@ import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { alertState } from 'recoils/alert';
+import { sideBarState } from 'recoils/sideBar';
+import { openModalState } from 'recoils/modal';
 
 import { Chat, RoomType, UserImageMap } from 'types/chatTypes';
 
@@ -38,6 +40,8 @@ export default function Chattings({
   const { t } = useTranslation('channels');
   const router = useRouter();
   const setAlert = useSetRecoilState(alertState);
+  const setModal = useSetRecoilState(openModalState);
+  const setSideBar = useSetRecoilState(sideBarState);
   const [chats, setChats] = useState<Chat[]>([]);
   const [message, setMessage] = useState<string>('');
   const [showPreview, setShowPreview] = useState<boolean>(false);
@@ -102,6 +106,8 @@ export default function Chattings({
       type: 'warning',
       message: data.type === 'kick' ? t('kick') : t('ban'),
     });
+    setModal(false);
+    setSideBar(null);
     router.push('/channels');
   }, []);
 


### PR DESCRIPTION
## Issue
+ Issue Number: #484 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
채널에서 사이드 바 또는 모달이 열려있는 상태에서 kick이나 ban으로 강퇴당하면
열려있던 사이드 바 또는 모달이 닫히지 않고 미아 상태로 둥둥 떠있어요.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
채널 강퇴 시 사이드 바와 모달 모두 닫아주겠습니다.

## Etc
