### PR TITLE
[fix]  광고 위치 변경 때문에 생기는 이슈들 총망라 #488

### DIFF
--- a/components/layouts/AdsLayout.tsx
+++ b/components/layouts/AdsLayout.tsx
@@ -8,6 +8,10 @@ import GoogleAd from 'components/global/GoogleAd';
 
 import styles from 'styles/layouts/AdsLayout.module.scss';
 
+const isTouchScreen =
+  typeof window !== 'undefined' &&
+  window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
 export default function AdsLayout({ children }: LayoutProps) {
   const [direction, setDirection] = useState<'row' | 'column'>(window.innerHeight / window.innerWidth < 1.3 ? 'row' : 'column');
   const router = useRouter();
@@ -25,34 +29,40 @@ export default function AdsLayout({ children }: LayoutProps) {
     };
   }, []);
 
-  if (direction === 'row' || router.query.roomId) {
-    return (
-      <div className={styles.adsLayoutRow}>
-        <GoogleAd
-          client='ca-pub-5861134754944224'
-          slot='4781852804'
-          format='vertical'
-          responsive='true'
-        />
-        {children}
-        <GoogleAd
-          client='ca-pub-5861134754944224'
-          slot='4781852804'
-          format='vertical'
-          responsive='true'
-        />
-      </div>
-    );
-  }
+  if (isTouchScreen && router.query.roomId) return <>{children}</>;
+
   return (
-    <div className={styles.adsLayoutColumn}>
+    <div
+      className={
+        direction === 'row' || router.query.roomId
+          ? styles.adsLayoutRow
+          : styles.adsLayoutColumn
+      }
+    >
+      {(direction === 'row' || router.query.roomId) && (
+        <GoogleAd
+          client='ca-pub-5861134754944224'
+          slot='4781852804'
+          format='vertical'
+          responsive='true'
+        />
+      )}
       {children}
-      <GoogleAd
-        client='ca-pub-5861134754944224'
-        slot='9772393400'
-        format='horizontal'
-        responsive='true'
-      />
+      {(direction === 'row' && !router.query.roomId) ? (
+        <GoogleAd
+          client='ca-pub-5861134754944224'
+          slot='4781852804'
+          format='vertical'
+          responsive='true'
+        />
+      ) : (
+        <GoogleAd
+          client='ca-pub-5861134754944224'
+          slot='9772393400'
+          format='horizontal'
+          responsive='true'
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Issue
+ Issue Number: #488 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
윈도우 가로 크기에 따라 광고 위치가 column 또는 row로 설정되는데요,
현재 레이아웃 특성상 AdsLayout이 내부 컴포넌트들을 모두 감싸고 있기 때문에
컴포넌트들이 전부 리랜더링되면서 생기는 이슈들이 몇 가지 있습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
알고보니 AdsLayout에서 children이 조건부 렌더링에 영향을 받고 있었기 때문에 리랜더링 되는 것이었습니다...
따라서 children을 조건문 밖에 위치해주었더니 해결되었지만 리턴문이 아주 조금 난잡해졌습니다.
추가로 게임 & 챗 페이지 모바일 뷰에서는 광고를 뗐습니다.

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
