### PR TITLE
[fix] logout시 router가 아닌 새 페이지 로드 #493

### DIFF
--- a/hooks/useAuthHandler.ts
+++ b/hooks/useAuthHandler.ts
@@ -81,7 +81,7 @@ const useAuthHandler = () => {
     closeUpperModal();
     setSideBar(null);
     queryClient.invalidateQueries(['userMe']);
-    router.push('/');
+    window.location.href = '/';
   };
 
   const onUnauthorizedAttempt = () => {


### PR DESCRIPTION
## Issue
+ Issue Number: #493 
+ PR Type: `fix`
## Summary
<!-- 해당 기능에 대한 요약글 -->
지금은 로그아웃을 하면 `router.push('/')`를 통해 홈으로 보내줍니다.
그렇게 되면 LoginFilter에 걸려 loginRequiredModal이 뜨고
router.push를 했어도 아직 이 전 페이지에 남아있어 이런 저런 예상치 못한 에러가 뜹니다.
따라서 로그아웃을 하면 `window.location.href = '/'`로 이전 페이지의 모든 내용을 날리고 새로운 홈 페이지를 로드합니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
Setting의 onLogout에서 `window.location.href = '/'` 페이지 이동

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
