### PR TITLE
[fix] 게임 결과 페이지 사소한 문제점들 해결하기 + 게임이모지 조금 수정 #504

### DIFF
--- a/components/game/result/GameResultDetail.tsx
+++ b/components/game/result/GameResultDetail.tsx
@@ -30,11 +30,14 @@ export default function GameResultDetail({
   const [showFireworks, setShowFireworks] = useState(false);
 
   useEffect(() => {
-    if (showFireworks) {
-      const container = document.getElementById('fireworks') ?? document.body;
-      const fireworks = new Fireworks(container, options);
-      fireworks.start();
-    }
+    if (!showFireworks) return;
+    const container = document.getElementById('fireworks') ?? document.body;
+    const fireworks = new Fireworks(container, options);
+    fireworks.start();
+    return () => {
+      fireworks.stop();
+      setShowFireworks(false);
+    };
   }, [showFireworks]);
   if (isLoading) return <LoadingSpinner />;
   if (isError) return <ErrorRefresher error={error} />;

--- a/components/game/result/LpProgressBar.tsx
+++ b/components/game/result/LpProgressBar.tsx
@@ -21,7 +21,7 @@ export default function LpProgressBar({
   const { t: tTier } = useTranslation('tier');
 
   const getTierName = (lp: number): Tier[] => {
-    if (lp >= DOCTOR_CUT) return ['doctor', 'doctor'];
+    if (lp >= DOCTOR_CUT) return ['doctor', ''];
     if (lp >= MASTER_CUT) return ['master', 'doctor'];
     if (lp >= BACHELOR_CUT) return ['bachelor', 'master'];
     if (lp >= STUDENT_CUT) return ['student', 'bachelor'];
@@ -85,7 +85,7 @@ export default function LpProgressBar({
   );
 }
 
-const DOCTOR_CUT = 100;
-const MASTER_CUT = 50;
-const BACHELOR_CUT = 10;
-const STUDENT_CUT = 1;
+const DOCTOR_CUT = 1500;
+const MASTER_CUT = 1200;
+const BACHELOR_CUT = 1000;
+const STUDENT_CUT = 800;

--- a/i18n.json
+++ b/i18n.json
@@ -8,7 +8,7 @@
     "/channels": ["chats", "channels"],
     "/friends": ["friends"],
     "/game": ["game", "guide"],
-    "/game/[roomType]/[roomId]": ["game", "achievement"],
+    "/game/[roomId]": ["game", "achievement"],
     "/leaderboard": ["leaderboard"],
     "/records/[[...nickname]]": ["records"],
     "/myPage": ["myPage", "common", "achievement"],

--- a/styles/game/Emojis.module.scss
+++ b/styles/game/Emojis.module.scss
@@ -9,6 +9,14 @@
 
 .emojiWrap {
   position: relative;
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  -ms-user-select:none;
+  user-select:none
+}
+
+.emojiWrap:hover {
+  transform: scale(0.95);
 }
 
 .emoji {
@@ -28,8 +36,4 @@
   position: absolute;
   right: 0.5rem;
   top: 0;
-}
-
-.emoji:hover {
-  transform: scale(0.95);
 }

--- a/styles/game/Game.module.scss
+++ b/styles/game/Game.module.scss
@@ -6,6 +6,9 @@
 
 .gameContainer {
   @include pageContainer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .pongFrameContainer {

--- a/styles/records/Player.module.scss
+++ b/styles/records/Player.module.scss
@@ -1,3 +1,5 @@
+@import 'styles/common';
+
 .playerContainer {
   display: grid;
   gap: 0.5rem;
@@ -6,5 +8,6 @@
     width: 5rem;
     object-fit: contain;
     aspect-ratio: 1/1;
+    border-radius: $basic-radius;
   }
 }

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -1,6 +1,6 @@
 export type ProfileStyle = 'modal' | 'page';
 export type ProfileTab = 'profile' | 'achieve' | 'emoji';
-export type Tier = 'doctor' | 'master' | 'bachelor' | 'student' | 'egg';
+export type Tier = 'doctor' | 'master' | 'bachelor' | 'student' | 'egg' | '';
 
 export interface User {
   nickname: string;


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #504
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
게임 결과 페이지 번역이 안되던 문제,
폭죽이 시도때도 없이 터지는 문제,
화면의 상단에 위치하던 문제,,,
밑에 등급컷을 백과 맞추기 등등 했구요..
프사도 조금 둥굴리고
그리고 이모지 호버할 때 숫자는 가만히 있던 문제
숫자 드래그 되는 문제 까지 수정했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
<img width="497" alt="스크린샷 2023-08-24 오후 2 19 18" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/12b5f400-e385-4941-89c8-b090f8e9591f">

## Etc
