### PR TITLE
[fix] 구글 애드 콘솔에 자꾸 에러 뜨는거 해결하기 #523

### DIFF
--- a/components/global/GoogleAd.tsx
+++ b/components/global/GoogleAd.tsx
@@ -11,15 +11,6 @@ export default function GoogleAd({
   slot?: string;
   format?: string;
 }) {
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return;
-    window.onload = () => {
-      ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push(
-        {}
-      );
-    };
-  }, []);
-
   if (process.env.NODE_ENV !== 'production')
     return (
       <div

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -52,6 +52,7 @@
   "Add friend": "Add friend",
   "Participants": "Participants",
   "needLogin": "This feature requires login.",
+  "Unauthorized": "This feature requires login.",
   "move to my page": "move to my page",
   "guide": "Hitchhiker's Guide To Dr.Pong",
   "inGameNotify": "There is a game in progress.",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -52,6 +52,7 @@
   "Add friend": "친구 추가",
   "Participants": "대화상대",
   "needLogin": "로그인이 필요합니다.",
+  "Unauthorized": "로그인이 필요합니다.",
   "move to my page": "마이 페이지로 이동",
   "guide": "조작법",
   "inGameNotify": "진행중인 게임이 있습니다.",


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #523
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
자꾸 뜨던 에러를 해결했습니다.
그리고 로그아웃된 상태에서 큐돌리면 "Unauthorized"라고 와서요
요거 로케일 여따 끼워넣습니당 

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 구글 애드를 적용하는 방법중에 스크립트를 각 컴포넌트에서 수동으로 적용하기 / head에 스크립트를 적용하기가 있습니다.
- 구글 애드에서 하라는대로 했더니 이게 2개가 다 들어가버렸어요
- 그래서 head에서만 스크립트를 적용하도록 바꿨습니다.

## Etc
