### PR TITLE
[feat] scroll debouncer #526

### DIFF
--- a/components/chats/Chattings.tsx
+++ b/components/chats/Chattings.tsx
@@ -23,6 +23,8 @@ import useChatQuery from 'hooks/useChatQuery';
 import useChatSocket from 'hooks/useChatSocket';
 import useCustomQuery from 'hooks/useCustomQuery';
 
+import { debouncer } from 'utils/debouncer';
+
 import ChatBox from 'components/chats/ChatBox';
 import ChatFailButtons from 'components/chats/ChatFailButtons';
 import ChatInputBox from 'components/chats/ChatInputBox';
@@ -168,7 +170,7 @@ export default function Chattings({
     setMessage('');
   }, []);
 
-  const handleScroll = () => {
+  const handleScroll = debouncer(() => {
     const ref = chattingsRef.current!;
 
     // 스크롤이 맨 위에 있는 경우
@@ -187,7 +189,7 @@ export default function Chattings({
       setShowPreview(false);
       setNewestChat(null);
     }
-  };
+  }, 200);
 
   return (
     <div className={styles.chattingsContainer}>

--- a/utils/debouncer.ts
+++ b/utils/debouncer.ts
@@ -1,0 +1,17 @@
+let timer: NodeJS.Timeout | null = null;
+
+export const debouncer = <F extends (...args: any[]) => any>(
+  func: F,
+  delay: number
+) => {
+  const debounced = (...args: Parameters<F>) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      func(...args);
+      timer = null;
+    }, delay);
+  };
+  return debounced as (...args: Parameters<F>) => ReturnType<F>;
+};


### PR DESCRIPTION
## Issue
+ Issue Number: #526 
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
스크롤 함수가 와다다다 호출되는 것이 별로라고 생각이 되었소.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 디바운서를 추가했어요~
- 마지막 스크롤 요청 후 200 밀리세컨드 동안 새로운 요청이 없어야 함수가 실행됩니다.
- 대기 시간을 더 길게 주고싶엇지만, 함수에 fetch 요청만 잇는게 아니라서 좀 줄였습니다.

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
