### PR TITLE
[fix] 모바일에서 채팅 인풋창 포커스 아웃 #533

### DIFF
--- a/components/chats/ChatInputBox.tsx
+++ b/components/chats/ChatInputBox.tsx
@@ -3,6 +3,9 @@ import React, {
   Dispatch,
   SetStateAction,
   useCallback,
+  useRef,
+  FormEvent,
+  MouseEvent
 } from 'react';
 import { RiSendPlaneFill } from 'react-icons/ri';
 
@@ -21,33 +24,47 @@ export default function ChatInputBox({
   handleChatPost,
   inputDisabled,
 }: ChatInputBoxProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const handleMessageChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      if (messageOverLengthLimit(event.target.value))
+      if (messageOverLengthLimit(event.target.value)) {
         event.target.value = event.target.value.substring(0, 100);
+      }
       setMessage(event.target.value);
     },
     [message]
   );
 
-  const handleChatSubmit = useCallback(
-    (e: React.FormEvent | React.MouseEvent) => {
-      e.preventDefault();
-      handleChatPost(message);
-    },
-    [message]
+  const handleInputClick = () => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
+  const handleChatSubmit = useCallback((e: FormEvent | MouseEvent) => {
+    e.preventDefault();
+    handleChatPost(message);
+    handleInputClick();
+  },
+    [handleChatPost, message]
   );
 
   return (
     <form className={styles.chatInputBoxContainer} onSubmit={handleChatSubmit}>
       <input
+        ref={inputRef}
         className={styles.input}
         type='text'
         value={message}
         onChange={handleMessageChange}
         disabled={inputDisabled}
+        onClick={handleInputClick}
       />
-      <RiSendPlaneFill className={styles.sendIcon} onClick={handleChatSubmit} />
+      <RiSendPlaneFill
+        className={styles.sendIcon}
+        onClick={handleChatSubmit}
+      />
     </form>
   );
 }


### PR DESCRIPTION
## Issue
+ Issue Number: #533
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
채팅을 할 때 pc에서는 input 창이 focus된 채로 잘 유지가 되는데
모바일로 접속했을 때는 챗을 send할 때마다 스크롤이 하나씩 밀리고
키보드가 사라지면서 focus 아웃 되는 이슈가 있습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- useRef를 이용해 chat submit 할 때마다 input 창이 focus되게 하였습니다.

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
