### PR TITLE
[fix] 게임 종료 후 메인으로 돌아갈 때 어치브먼트 토스트 꺼주기 #542

### DIFF
--- a/components/game/PongFrame.tsx
+++ b/components/game/PongFrame.tsx
@@ -17,11 +17,10 @@ import useUpperModalProvider from 'hooks/useUpperModalProvider';
 import Emojis from 'components/game/Emojis';
 import MatchProfile from 'components/game/MatchProfile';
 import GameResult from 'components/game/result/GameResult';
+import AchievementToast from 'components/toasts/AchievementToast';
+import TitleToast from 'components/toasts/TitleToast';
 
 import styles from 'styles/game/Game.module.scss';
-
-import AchievementToast from '../toasts/AchievementToast';
-import TitleToast from '../toasts/TitleToast';
 
 type PongFrameProps = {
   canvasWidth: number;

--- a/components/game/PongGame.tsx
+++ b/components/game/PongGame.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect } from 'react';
-import toast from 'react-hot-toast';
 
 import useGameSocket from 'hooks/useGameSocket';
 
 import GameCanvas from 'components/game/GameCanvas';
-import AchievementToast from 'components/toasts/AchievementToast';
-import TitleToast from 'components/toasts/TitleToast';
 
 import styles from 'styles/game/PongGame.module.scss';
 
@@ -82,26 +79,6 @@ const PongGame = ({ roomId, canvasWidth, canvasHeight }: PongGameProps) => {
         document.removeEventListener('keydown', handleKeyPress);
         document.removeEventListener('keyup', handleKeyRelease);
       }
-    };
-  }, []);
-
-  const achievementListener = (achievement: {
-    imgUrl: string;
-    name: string;
-  }) => {
-    toast.custom(() => <AchievementToast achievement={achievement} />);
-  };
-
-  const titleListener = (title: { title: string }) => {
-    toast.custom(() => <TitleToast title={title} />);
-  };
-
-  useEffect(() => {
-    socket.on('achievement', achievementListener);
-    socket.on('title', titleListener);
-    return () => {
-      socket.off('achievement', achievementListener);
-      socket.off('title', titleListener);
     };
   }, []);
 


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #542
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
자꾸 해마가 대빵만하게 뜨는거 해결해 보려고
결과페이지에서 나갈 때 토스트를 꺼줘보았습니다.
어떨까요?

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 결과페이지 언마운트시에 토스트 없애주기

## Etc
