### PR TITLE
[style] 승률 게이지랑 버튼 정렬 수정 #547

### DIFF
--- a/components/friends/FriendButtons.tsx
+++ b/components/friends/FriendButtons.tsx
@@ -27,7 +27,7 @@ export default function FriendButtons({ tab, nickname }: FriendButtonsProps) {
   const buttons: { [key: string]: ReactNode } = {
     directMessage: (
       <BasicButton style='round' color='opaque'>
-        <Link href={`/chats/dm/${nickname}`}>
+        <Link className={styles.chatBoxIcon} href={`/chats/dm/${nickname}`}>
           <IoChatbox className={styles.chatBoxIcon} />
         </Link>
       </BasicButton>

--- a/components/global/UserBox.tsx
+++ b/components/global/UserBox.tsx
@@ -31,7 +31,7 @@ export default function UserBox({ children, type, friend }: UserBoxProps) {
       <div className={styles.nickname} onClick={handleNicknameClick}>
         {nickname}
       </div>
-      {children}
+      <div className={styles.button}>{children}</div>
     </div>
   );
 }

--- a/components/myPage/profile/WinRateStat.tsx
+++ b/components/myPage/profile/WinRateStat.tsx
@@ -24,10 +24,19 @@ export default function WinRateStat({
         'T'
       )} ${loses}${t('L')})`}</div>
       <div className={styles.gaugeBar}>
-        <div className={styles.winGauge} style={{ width: winRate + '%' }} />
+        <div
+          className={styles.winGauge}
+          style={{
+            width: `calc((100% - 0.5rem) * ${winRate / 100} + 0.5rem)`,
+            zIndex: winRate >= 50 ? 1 : 0,
+          }}
+        />
         <div
           className={styles.loseGauge}
-          style={{ width: 100 - winRate + '%' }}
+          style={{
+            width: `calc((100% - 0.5rem) * ${(100 - winRate) / 100} + 0.5rem)`,
+            zIndex: winRate < 50 ? 1 : 0,
+          }}
         />
       </div>
     </div>

--- a/styles/global/UserBox.module.scss
+++ b/styles/global/UserBox.module.scss
@@ -36,3 +36,10 @@
   font-family: $bold-font;
   cursor: pointer;
 }
+
+.button {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}

--- a/styles/myPage/WinRateStat.module.scss
+++ b/styles/myPage/WinRateStat.module.scss
@@ -20,18 +20,26 @@
 }
 
 .gaugeBar {
-  display: flex;
+  position: relative;
   width: 100%;
   height: 0.5rem;
   margin-block: 0.2rem;
 }
 
 .winGauge {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 0.5rem;
   background: linear-gradient(to bottom, $just-blue 60%, $dark-purple);
-  border-radius: 0.5rem 0 0 0.5rem;
+  border-radius: 0.5rem;
 }
 
 .loseGauge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 0.5rem;
   background: linear-gradient(to bottom, $just-pink 60%, $dark-purple);
-  border-radius: 0 0.5rem 0.5rem 0;
+  border-radius: 0.5rem;
 }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #547
+ PR Type: `style`

## Summary
<!-- 해당 기능에 대한 요약글 -->
승률 게이지 보더 문제 해결하고
사파리에서 DM버튼, 그리고 친구초대모달 +버튼 정렬문제(이건 크롬도) 해결했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 승률
- 승/패중에 많은게 나머지를 덮게 만들었습니다. 스샷 참고

<img width="256" alt="스크린샷 2023-09-20 오후 12 53 46" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/378ea436-73d0-4944-b566-e62505bb62bb">

- 원사이드


<img width="262" alt="스크린샷 2023-09-20 오후 12 53 51" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/abba8ed7-84c6-4e7e-ac69-fe12299683a0">

- 승 > 패


<img width="279" alt="스크린샷 2023-09-20 오후 12 53 55" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/0cd932a6-df4b-4947-b555-765b1db5c988">

- 패 > 승



- 버튼

<img width="301" alt="스크린샷 2023-09-20 오후 12 54 32" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/59f17e86-f2c2-490d-9017-184cd5cdf44e">
<img width="177" alt="스크린샷 2023-09-20 오후 12 54 23" src="https://github.com/Dr-Pong/dr_pong_client/assets/90166901/2e4cbbf5-3add-4174-953d-f644cccf33f6">

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->

## Etc
