### PR TITLE
[fix] 프로필 에딧 문제 긴급 해결.. #563

### DIFF
--- a/components/myPage/SelectTab.tsx
+++ b/components/myPage/SelectTab.tsx
@@ -18,6 +18,7 @@ import ErrorRefresher from 'components/global/ErrorRefresher';
 import SelectableItem from 'components/myPage/SelectableItem';
 
 import styles from 'styles/myPage/SelectTab.module.scss';
+import { bool } from "prop-types";
 
 export interface SelectHandler {
   select: (item: Selectable | null) => void;
@@ -35,6 +36,7 @@ export default function SelectTab({ nickname, itemType }: SelectTabProps) {
     nickname,
     selectables.getQuery()
   );
+  const [editClicked, setEditClicked] = useState<boolean>(false);
   const editable = useRecoilValue(editableState);
   const [selected, setSelected] = useState(
     new selectables(Array(itemType === 'achieve' ? 3 : 4).fill(null))
@@ -43,10 +45,8 @@ export default function SelectTab({ nickname, itemType }: SelectTabProps) {
   const { mutate } = selectablesMutationPatch();
 
   useEffect(() => {
-    if (selected.isEmpty()) {
-      return;
-    }
-    if (!editable) {
+    if (editable) setEditClicked(true);
+    if (!editable && editClicked) {
       mutate({ ...selected.getSelected() });
     }
   }, [editable]);

--- a/components/myPage/profile/Profile.tsx
+++ b/components/myPage/profile/Profile.tsx
@@ -34,6 +34,7 @@ export default function Profile({ nickname, style }: ProfileProps) {
   const editable = useRecoilValue(editableState);
   const profileTab = useRecoilValue(profileTabState);
   const [user, setUser] = useState<UserDetail>(defaultUser);
+  const [editClicked, setEditClicked] = useState<boolean>(false);
   const { profileGet, profileMutationPatch } = useMyPageQuery(nickname);
   const { patchImage, patchTitle, patchMessage } = profileMutationPatch();
   const { isLoading, isError } = profileGet(setUser);
@@ -42,7 +43,8 @@ export default function Profile({ nickname, style }: ProfileProps) {
   const [statusMessage, setStatusMessage] = useState<string>('');
 
   useEffect(() => {
-    if (!editable && profileTab === 'profile') {
+    if (editable) setEditClicked(true);
+    if (!editable && profileTab === 'profile' && editClicked) {
       if (image.id && image !== user.image)
         patchImage.mutate({
           id: image.id,


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #563
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
이모지와 업적이 저장하고 프로필페이지 다시 들어가기만 하면 사라지는 좃버그가 있었습니다..

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 문제가 생긴거는 지휴킴이 업적/이모지를 null로 채워넣기 시작하고 터진거였습니다.
- 이게 무슨일이냐? 우리가(내가) 에딧버튼을 좃가치 만들어놔서, 항상 프로필 페이지 / 탭 이동시마다 patch 요청을 보내줍니다.
- 매번 보내기 좀 그러니까 전의 상태를 검사하거나 초기상태(비어있는)인지 확인하고 보냈었는데, 이걸 selectable 배열의 길이가 0인지로 확인했습니다.
- 근데 이제 null로 배열이 꽉차면서 배열 길이가 생기었죠??ㅠㅠ
- 근데 널만 꽉찬걸 빈 상태라고 보기에는 누군가는 이모지와 업적을 다 빼고 싶을 수도 있잖아요?

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->
- 그래서 edit 버튼이 눌린 적이 있는지 보는 상태를 하나 만들어서 해결했습니다..
## Etc
