### PR TITLE
[fix] 디바운서 -> 쓰로틀러, 조금 더 밑에서 트리거 #567

### DIFF
--- a/components/chats/Chattings.tsx
+++ b/components/chats/Chattings.tsx
@@ -23,7 +23,7 @@ import useChatQuery from 'hooks/useChatQuery';
 import useChatSocket from 'hooks/useChatSocket';
 import useCustomQuery from 'hooks/useCustomQuery';
 
-import { debouncer } from 'utils/debouncer';
+import { throttler } from 'utils/throttler';
 
 import ChatBox from 'components/chats/ChatBox';
 import ChatFailButtons from 'components/chats/ChatFailButtons';
@@ -170,14 +170,14 @@ export default function Chattings({
     setMessage('');
   }, []);
 
-  const handleScroll = debouncer(() => {
+  const handleScroll = throttler(() => {
     const ref = chattingsRef.current!;
 
     // 스크롤이 맨 위에 있는 경우
     if (
       hasNextPage &&
       !isFetchingNextPage &&
-      Math.abs(ref.scrollTop) > ref.scrollHeight - ref.clientHeight - 100
+      Math.abs(ref.scrollTop) > ref.scrollHeight - ref.clientHeight - 200
     )
       fetchNextPage();
 


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #567
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
모바일에서 채팅 스크롤 올리면
깜빡 하고 맨위로 올라가 버리는 버그가 있습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 디바운서때문인거같대서
- 일단 쓰로틀러로 고쳐봤는데 잘 되는 것 같아요
- 그리고 무한스크롤 트리거가 조금 더 부드럽게 되라고 트리거되는 위치를 낮췄습니다.

## Etc
