### PR TITLE
[fix] 여러판 할 때 잔상이 안 남는 문제 해결과 게임 매치 사운드 래더에서도 나게 #578

### DIFF
--- a/components/game/GameCanvas.tsx
+++ b/components/game/GameCanvas.tsx
@@ -272,6 +272,7 @@ export default function GameCanvas({
   useEffect(() => {
     return () => {
       if (timer) clearTimeout(timer);
+      lastDrawnFrame = 0;
     };
   }, []);
 

--- a/components/game/GameCanvas.tsx
+++ b/components/game/GameCanvas.tsx
@@ -270,9 +270,9 @@ export default function GameCanvas({
   }, [me, opponent, ball, countdown, server, round, myScore, opponentScore]);
 
   useEffect(() => {
+    lastDrawnFrame = 0;
     return () => {
       if (timer) clearTimeout(timer);
-      lastDrawnFrame = 0;
     };
   }, []);
 

--- a/pages/game/index.tsx
+++ b/pages/game/index.tsx
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 import useTranslation from 'next-translate/useTranslation';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { useRouter } from 'next/router';
 
@@ -8,10 +8,12 @@ import React, { ReactElement, useState } from 'react';
 import { BsQuestionSquare } from 'react-icons/bs';
 
 import { alertState } from 'recoils/alert';
+import { soundEffectState } from 'recoils/sound';
 
 import useCustomQuery from 'hooks/useCustomQuery';
 import useGameSocket from 'hooks/useGameSocket';
 import useModalProvider from 'hooks/useModalProvider';
+import { useSoundEffect } from 'hooks/useSoundEffect';
 import useUpperModalProvider from 'hooks/useUpperModalProvider';
 
 import { GameButtons } from 'components/game/GameButtons';
@@ -28,6 +30,8 @@ export default function Game() {
   const { useGameGuideModal } = useModalProvider();
   const { closeUpperModal, useMatchWaitingUpperModal } =
     useUpperModalProvider();
+  const { effects } = useSoundEffect();
+  const isSoundEffectOn = useRecoilValue(soundEffectState);
   const [socket] = useGameSocket('matching');
   const [normalClicked, setNormalClicked] = useState(false);
   const { mutationPost, mutationDelete } = useCustomQuery();
@@ -54,6 +58,7 @@ export default function Game() {
 
   const matchedListener = (data: { roomId: string }) => {
     closeUpperModal();
+    effects.get('game_start')?.(isSoundEffectOn);
     router.push(`/game/${data.roomId}`);
   };
 


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #578
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
여러 판 게임을 할 때 두 번째 게임부터 잔상이 안남는 문제를 해결했습니다.
게임 매치 사운드가 래더에서는 안나는 점도 해결했습니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 여러판 할 때 잔상이 안남는 이유는 lastDrawnIndex를 전역으로 관리하고 있어서 였습니다.. 저게 지역변수면 렌더링 때마다 초기화되면서 잘 안되어갖고 전역으로 뺐는데, 게임에 다시 들어와도 이게 초기화가 안되나봐요. 그래서 유즈이펙트에서 초기화 해주기로 했습니다.
- 매치사운드는.. ㅎㅎ 게임 로비에서만 코드를 손댔었는데 래더는 페이지/index에서 하더라고요? .. ㅎ

## Etc
